### PR TITLE
Fixed image link on travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![build status](https://travis-ci.org/starekrow/lockbox.svg?branch=master)
+[![build status](https://travis-ci.org/starekrow/lockbox.svg?branch=master)](https://travis-ci.org/starekrow/lockbox)
 
 # Lockbox
 


### PR DESCRIPTION
Travis badge should be a link to Travis-ci